### PR TITLE
Updated incorrect links from original source

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-# These are supported funding model platforms
-buy_me_a_coffee: chris.williams

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://astro-cactus.chriswilliams.dev/sitemap-index.xml
+Sitemap: https://mbleigh.dev/sitemap-index.xml

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -25,7 +25,7 @@ export const siteConfig: SiteConfig = {
 	title: "mbleigh.dev",
 	webmentions: {
 		// Webmention.io API endpoint. Get your own here: https://webmention.io/, and follow this blog post: https://astro-cactus.chriswilliams.dev/posts/webmentions/
-		link: "https://webmention.io/astro-cactus.chriswilliams.dev/webmention",
+		link: "https://webmention.io/mbleigh.dev/webmention",
 	},
 };
 


### PR DESCRIPTION
I'm migrating my personal site to Astro and have used this repo as a helpful refence. Figured I'd repay you in a very small way by fixing a few things I noticed. The sitemap one is probably the most important as that likely has real SEO implications. You may also want to do an audit for other stuff from your original source (e.g the PR template for this repo doesn't make sense and web mentions are not super relevant in 2024).

Anyway, thanks for making your code open source 😄 